### PR TITLE
Add recommended tags and overall emotion from foundation model

### DIFF
--- a/Reverie/Common/Services/FirebaseService.swift
+++ b/Reverie/Common/Services/FirebaseService.swift
@@ -12,6 +12,7 @@ import FoundationModels
 public class FirebaseService {
     let db = Firebase.db
     let tagsModelSession = FoundationModel.tagsModelSession
+    let emotionsModelSession = FoundationModel.emotionsModelSession
     
     func getUserInfo() async throws -> [String] {
         let userRef = db.collection("USERS").document("OtAj4vL9Xzz8lsm4nCuL")
@@ -33,12 +34,28 @@ public class FirebaseService {
     func getRecommendedTags(dreamText: String) async throws -> [DreamModel.Tags] {
         do {
             let response = try await tagsModelSession.respond(to: dreamText)
-            let data = try response.content.data(using: .utf8)!
+            let data = response.content.data(using: .utf8)!
             let tags = try JSONDecoder().decode([DreamModel.Tags].self, from: data)
             return tags
         } catch {
             print(error)
             return []
+        }
+    }
+    
+    func getEmotion(dreamText: String) async throws -> DreamModel.Emotions {
+        do {
+            let response = try await emotionsModelSession.respond(to: dreamText)
+            let content = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if let emotion = DreamModel.Emotions(rawValue: content) {
+                return emotion
+            }
+            
+            return .neutral
+        } catch {
+            print(error)
+            return .neutral
         }
     }
 }

--- a/Reverie/Common/Services/FoundationModel.swift
+++ b/Reverie/Common/Services/FoundationModel.swift
@@ -11,4 +11,7 @@ import FoundationModels
 public class FoundationModel {
     private static let tagsInstructions: String = "You are given a dream text. The only valid dream tags are: \(DreamModel.Tags.allCases.map { $0.rawValue }.joined(separator: ", ")). Identify which of these tags are relevant to the dream. Return your answer strictly as a JSON array of strings, for example: [\"family\", \"friends\"]. Rules: - You may include only tags from the list above. - Do not invent or modify tag names. - If none of the tags apply, return []. - Return only the array — no explanations or extra text."
     static let tagsModelSession = LanguageModelSession(instructions: tagsInstructions)
+    
+    private static let emotionsInstructions: String = "You are given a dream text. The only valid emotions are: \(DreamModel.Emotions.allCases.map { $0.rawValue }.joined(separator: ", ")). Identify the single overall emotion that best matches the dream. Return your answer strictly as a string, for example: \"happiness\". Rules: - You must return exactly one emotion from the list above. - Do not invent, modify, or explain emotions. - If no emotion clearly applies, return \"neutral\". - Return only the string — no array, no extra text, no explanation."
+    static let emotionsModelSession = LanguageModelSession(instructions: emotionsInstructions)
 }


### PR DESCRIPTION
## Add suggested tags
Implements #96 and #59

- Prompting Foundation Models for suggested tags as an array of strings
- Convert an array of strings to an array of enums
- Prompting Foundation Models for an overall emotion

### Tags
Test 1:
Dream Prompt: "my dream was about mountains and school friends"
Response: [Reverie.DreamModel.Tags.mountains, Reverie.DreamModel.Tags.school]

Test 2:
Dream Prompt: "my dream was about nothing"
Response: []

### Emotion
Test 1:
Dream Prompt: "my dream was so happy!!"
Response: happiness

Test 2:
Dream Prompt: "my dream was about nothing"
Response: neutral